### PR TITLE
Support  sendInterpreterExecThreadGroupKill method to send gdb command

### DIFF
--- a/src/mi/interpreter.ts
+++ b/src/mi/interpreter.ts
@@ -20,3 +20,14 @@ export function sendInterpreterExecConsole(
         `-interpreter-exec --thread ${params.threadId} --frame ${params.frameId} console "${params.command}"`
     );
 }
+
+export function sendInterpreterExecThreadGroupKill(
+    gdb: GDBBackend,
+    params: {
+        threadGroupId: number;
+    }
+) {
+    return gdb.sendCommand(
+        `-interpreter-exec --thread-group i${params.threadGroupId} console kill`
+    );
+}


### PR DESCRIPTION
Currently, when user use terminate threads in Callstack view, this does not work. So, we need to support terminate threads request to handle this case.